### PR TITLE
Bugfix of memory leak when using STRUMPACK for particle projections

### DIFF
--- a/solvers/mod_strumpack.f90
+++ b/solvers/mod_strumpack.f90
@@ -393,7 +393,10 @@ module mod_strumpack
       call MPI_COMM_RANK(spss%comm, rank, ierr)
 
       if (spss%projection) then
-        if (rank.ne.0) allocate (rhs_vec%val(rhs_vec%n*rhs_vec%nrhs))
+        if (rank.ne.0) then
+          if (associated(rhs_vec%val)) deallocate(rhs_vec%val)
+          allocate (rhs_vec%val(rhs_vec%n*rhs_vec%nrhs))
+        endif
         call MPI_Bcast(rhs_vec%val, rhs_vec%n*rhs_vec%nrhs, MPI_DOUBLE_PRECISION, 0, spss%comm, ierr)
       endif
 


### PR DESCRIPTION
There is an allocation of rhs_vec%val without checking for pre-existing assignement in solvers/mod_strumpack.f90 which has been fixed. 

This showed up in a case with very high memory usage (n_elements > 100.000): 

<img width="825" height="582" alt="image" src="https://github.com/user-attachments/assets/609118d4-b0ae-478d-9867-250f016828c2" />
