### PR TITLE
GMRES Driver Improvements 

### DIFF
--- a/solvers/mod_gmres2.f90
+++ b/solvers/mod_gmres2.f90
@@ -21,11 +21,18 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
   integer :: n
   type(type_SP_SOLVER)  :: solver
   
-  real(kind=8) :: atol, rtol, gamma, delta, rho, rho0=0.0
+  real(kind=8) :: atol, rtol, gamma, delta, rho, scale_norm
   real(kind=8) :: norm_p, norm_p_new
   integer :: totit, maxit, restart, nrit, it, ldh, k, j
-  integer :: n_ortho 
-  logical :: no_conv, GSC=.false., GSM=.false., GSCI=.true., GSMI=.false.
+  integer :: n_ortho
+  logical :: no_conv, breakdown
+  logical :: GSC=.false., GSM=.false., GSCI=.true., GSMI=.false.
+  !> .true.  : right preconditioning, A M^-1 y = b -> minimises the TRUE residual ||b-Ax||
+  !> .false. : left  preconditioning, M^-1 A x = M^-1 b -> minimises ||M^-1 (b-Ax)||
+  !>           (this is what the legacy dpackgmres driver does, icntl(4)=1)
+  logical :: right_prec=.true.
+  !> Relative threshold below which h_{j+1,j} is treated as a (happy) breakdown
+  real(kind=8), parameter :: bd_tol = 1.d-14
   real(kind=8), dimension(:), allocatable, target :: givens_c, givens_s, hess, V, b_prec, b_, s_
 
   integer :: my_id, my_id_n, n_cpu, ierr
@@ -56,8 +63,22 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
 
   ldh = restart+1
 
-  no_conv = .true.
-  totit = 0;  
+  ! --- Reference norm for the relative stopping criterion ---
+  !     The caller (mod_sparse) hands us x0 = M^-1 b, i.e. an already good initial guess, so
+  !     ||r0|| is tiny and normalising by it would impose a far stricter test than the legacy
+  !     dpackgmres driver, which measures the backward error against the right hand side.
+  !     Normalise against ||b|| (right prec.) resp. ||M^-1 b|| (left prec.) instead.
+  if (right_prec) then
+    scale_norm = dnrm2(n, b(1:n), 1)
+  else
+    call prec(solver, b(1:n), b_prec(1:n), n, MPI_GLOB, MPI_COMM_N)
+    scale_norm = dnrm2(n, b_prec(1:n), 1)
+  endif
+  if (scale_norm .le. 0.d0) scale_norm = 1.d0
+
+  no_conv   = .true.
+  breakdown = .false.
+  totit = 0
 
   do while (no_conv)
     ! --- v_1 = A * x ---
@@ -66,10 +87,15 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
     ! --- v_1 = b - A * x (True residual) ---
     call daxpby(n, 1.d0, b(1:n), 1, -1.d0, V(1:n), 1)
 
+    ! --- Left preconditioning: v_1 = M^-1 (b - A * x) ---
+    if (.not. right_prec) then
+      call dcopy(n, V(1), 1, b_prec(1), 1)
+      call prec(solver, b_prec(1:n), V(1:n), n, MPI_GLOB, MPI_COMM_N)
+    endif
+
     ! --- rho = ||v_1||_2 ---
     rho = dnrm2(n, V(1:n), 1)
-    if (totit .eq. 0) rho0 = rho
-    if ((rho/rho0 < rtol) .or. (rho < atol)) then
+    if ((rho/scale_norm < rtol) .or. (rho < atol)) then
       no_conv = .false.
       exit
     endif
@@ -79,17 +105,28 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
     b_(2:restart+1) = 0.d0
     nrit = restart-1
     if (my_id.eq.0) then
-      write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/rho0
+      write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/scale_norm
       write(*, "(A)") "[GMRES] --- Restart ---"
     endif
 
     do it = 1, restart
       totit = totit +1
-      ! --- b_prec = M^-1 * v_j --- 
-      call prec(solver, V((it-1)*n+1:it*n), b_prec(1:n), n, MPI_GLOB, MPI_COMM_N)
+      if (right_prec) then
+        ! --- b_prec = M^-1 * v_j ---
+        call prec(solver, V((it-1)*n+1:it*n), b_prec(1:n), n, MPI_GLOB, MPI_COMM_N)
 
-      ! --- v_j+1 = A * b_prec = A * M^-1 * v_j --- 
-      call bcsr_matv(a_mat, b_prec(1:n), V(it*n+1:(it+1)*n))
+        ! --- v_j+1 = A * b_prec = A * M^-1 * v_j ---
+        call bcsr_matv(a_mat, b_prec(1:n), V(it*n+1:(it+1)*n))
+      else
+        ! --- b_prec = A * v_j ---
+        call bcsr_matv(a_mat, V((it-1)*n+1:it*n), b_prec(1:n))
+
+        ! --- v_j+1 = M^-1 * b_prec = M^-1 * A * v_j ---
+        call prec(solver, b_prec(1:n), V(it*n+1:(it+1)*n), n, MPI_GLOB, MPI_COMM_N)
+      endif
+
+      ! --- Norm of the un-orthogonalized vector (reference for the breakdown test) ---
+      norm_p = dnrm2(n, V(it*n+1), 1)
 
       ! --- Orthogonalization ---
       if (GSC) then ! Gram-Schmidt Classical
@@ -100,8 +137,7 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
           hess(k+(it-1)*ldh) = ddot(n, V((k-1)*n+1), 1, V(it*n+1), 1)
           call daxpy(n, -hess(k+(it-1)*ldh), V((k-1)*n+1), 1, V(it*n+1), 1)
         enddo
-      elseif (GSCI) then ! Gram-Schmidt Classical Iterative 
-        norm_p = dnrm2(n, V(it*n+1), 1)
+      elseif (GSCI) then ! Gram-Schmidt Classical Iterative
         hess((it-1)*ldh+1:(it-1)*ldh+1+it) = 0.d0
         do j=1,n_ortho
           call dgemv('C', n, it, 1.d0, V(1), n, V(it*n+1), 1, 0.d0, s_(1), 1)
@@ -112,7 +148,6 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
           norm_p = norm_p_new
         enddo
       elseif (GSMI) then ! Gram-Schmidt Modified Iterative
-        norm_p = dnrm2(n, V(it*n+1), 1)
         hess((it-1)*ldh+1:(it-1)*ldh+1+it) = 0.d0
         do j=1,n_ortho
           do k=1,it
@@ -127,8 +162,17 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
       endif
       ! --- h_j+1,j = ||v_j+1||_2 ---
       hess(it+(it-1)*ldh+1) = dnrm2(n, V(it*n+1), 1)
-      ! --- v_j+1 = v_j+1 / h_j+1,j --- 
-      call dscal(n, 1./hess(it+(it-1)*ldh+1), V(it*n+1), 1)
+      ! --- Breakdown test: the new direction has been fully cancelled by the orthogonalization,
+      !     i.e. the exact solution already lies in the current Krylov subspace. Normalising here
+      !     would divide by (almost) zero and poison the whole basis with Inf/NaN.
+      if (hess(it+(it-1)*ldh+1) .le. bd_tol*max(norm_p, atol)) then
+        hess(it+(it-1)*ldh+1) = 0.d0
+        V(it*n+1:(it+1)*n) = 0.d0
+        breakdown = .true.
+      else
+        ! --- v_j+1 = v_j+1 / h_j+1,j ---
+        call dscal(n, 1.d0/hess(it+(it-1)*ldh+1), V(it*n+1), 1)
+      endif
       ! --- Givens Rotation ---
       do k = 1, it-1
         gamma = givens_c(k)*hess(k+(it-1)*ldh) + givens_s(k)*hess(k+(it-1)*ldh+1)
@@ -136,30 +180,46 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
         hess(k+(it-1)*ldh) = gamma
       enddo
       delta = sqrt(abs(hess(it+(it-1)*ldh))**2 + hess(it+(it-1)*ldh+1)**2);
-      givens_c(it) = hess(it+(it-1)*ldh) / delta
-      givens_s(it) = hess(it+(it-1)*ldh+1) / delta
+      if (delta .le. 0.d0) then
+        ! Hard breakdown: the whole column vanished, no further progress is possible.
+        givens_c(it) = 1.d0
+        givens_s(it) = 0.d0
+        breakdown = .true.
+      else
+        givens_c(it) = hess(it+(it-1)*ldh) / delta
+        givens_s(it) = hess(it+(it-1)*ldh+1) / delta
+      endif
       hess(it+(it-1)*ldh) = givens_c(it)*hess(it+(it-1)*ldh) + givens_s(it)*hess(it+(it-1)*ldh+1)
       b_(it+1) = -givens_s(it)*b_(it)
       b_(it) = givens_c(it)*b_(it)
       rho = abs(b_(it+1))
-      if (my_id.eq.0) write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/rho0
-      if ((rho < atol).or.(rho/rho0 < rtol).or.(totit >= maxit)) then
+      if (my_id.eq.0) write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/scale_norm
+      if ((rho < atol).or.(rho/scale_norm < rtol).or.(totit >= maxit).or.breakdown) then
         no_conv = .false.
         nrit = it-1
-        solver%iter_gmres = totit
         exit
       endif
 
     enddo
     ! --- Solve upper triangular system b_ = H \ b_ ---
     call dtrsv('U', 'N', 'N', nrit+1, hess, ldh, b_, 1)
-    ! --- Form z = V * b_ --- 
-    call dgemv('N', n, nrit+1, 1.d0, V(1), n, b_(1), 1, 0.d0, b_prec(1:n), 1)
-    ! --- Update solution x = x + M^-1 * z ---
-    call prec(solver, b_prec(1:n), V(1:n), n, MPI_GLOB, MPI_COMM_N)
-    call daxpy(n, 1.d0, V(1:n), 1, x(1:n), 1)
+    if (right_prec) then
+      ! --- Form z = V * b_ ---
+      call dgemv('N', n, nrit+1, 1.d0, V(1), n, b_(1), 1, 0.d0, b_prec(1:n), 1)
+      ! --- Update solution x = x + M^-1 * z ---
+      call prec(solver, b_prec(1:n), V(1:n), n, MPI_GLOB, MPI_COMM_N)
+      call daxpy(n, 1.d0, V(1:n), 1, x(1:n), 1)
+    else
+      ! --- Update solution x = x + V * b_ ---
+      call dgemv('N', n, nrit+1, 1.d0, V(1), n, b_(1), 1, 1.d0, x(1:n), 1)
+    endif
 
   enddo
+
+  ! --- Report the iteration count on EVERY exit path. The caller derives step_success from
+  !     (iter_gmres < iter_max) and pre-sets iter_gmres = iter_max, so leaving it untouched
+  !     after a successful solve would be reported as a failed step.
+  solver%iter_gmres = totit
 
   deallocate(givens_c,givens_s,b_,hess,V,b_prec)
   if (GSCI .or. GSMI) deallocate(s_) 

--- a/solvers/mod_gmres2.f90
+++ b/solvers/mod_gmres2.f90
@@ -22,7 +22,7 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
   type(type_SP_SOLVER)  :: solver
   
   real(kind=8) :: atol, rtol, gamma, delta, rho, rho0=0.0
-  real(kind=8) :: norm_p
+  real(kind=8) :: norm_p, norm_p_new
   integer :: totit, maxit, restart, nrit, it, ldh, k, j
   integer :: n_ortho 
   logical :: no_conv, GSC=.false., GSM=.false., GSCI=.true., GSMI=.false.
@@ -113,7 +113,9 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
           call dgemv('C', n, it, 1.d0, V(1), n, V(it*n+1), 1, 0.d0, s_(1), 1)
           call dgemv('N', n, it, -1.d0, V(1), n, s_(1), 1, 1.d0, V(it*n+1), 1)
           call daxpy(it, 1.d0, s_(1), 1, hess((it-1)*ldh+1), 1)
-          if (2.d0 * dnrm2(n, V(it*n+1), 1) .gt. norm_p) exit ! Stopping criterion for iterative GS methods
+          norm_p_new = dnrm2(n, V(it*n+1), 1)
+          if (2.d0 * norm_p_new .gt. norm_p) exit ! Stopping criterion for iterative GS methods
+          norm_p = norm_p_new
         enddo
       elseif (GSMI) then ! Gram-Schmidt Modified Iterative
         norm_p = dnrm2(n, V(it*n+1), 1)
@@ -124,7 +126,9 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
             call daxpy(n, -s_(k), V((k-1)*n+1), 1, V(it*n+1), 1)
           enddo
           call daxpy(it, 1.d0, s_(1), 1, hess((it-1)*ldh+1), 1)
-          if (2.d0 * dnrm2(n, V(it*n+1), 1) .gt. norm_p) exit ! Stopping criterion for iterative GS methods
+          norm_p_new = dnrm2(n, V(it*n+1), 1)
+          if (2.d0 * norm_p_new .gt. norm_p) exit ! Stopping criterion for iterative GS methods
+          norm_p = norm_p_new
         enddo
       endif
       ! --- h_j+1,j = ||v_j+1||_2 ---

--- a/solvers/mod_gmres2.f90
+++ b/solvers/mod_gmres2.f90
@@ -21,8 +21,7 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
   integer :: n
   type(type_SP_SOLVER)  :: solver
   
-  real(kind=8) :: atol, rtol, gamma, delta, rho, rho0=0.0, bnrm, scale_norm
-  real(kind=8) :: anrm2_loc, anrm2_glob, anrm, xnrm, nbe, nbe_denom
+  real(kind=8) :: atol, rtol, gamma, delta, rho, rho0=0.0
   real(kind=8) :: norm_p, norm_p_new
   integer :: totit, maxit, restart, nrit, it, ldh, k, j
   integer :: n_ortho 
@@ -57,16 +56,6 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
 
   ldh = restart+1
 
-  ! --- Compute RHS norm ||b||_2 ---
-  bnrm = dnrm2(n, b, 1)
-  if (bnrm == 0.d0) bnrm = 1.d0
-
-  ! --- Compute global matrix Frobenius norm ||A||_F ---
-  anrm2_loc = dnrm2(int(a_mat%nnz), a_mat%val, 1)**2
-  call MPI_Allreduce(anrm2_loc, anrm2_glob, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_GLOB, ierr)
-  anrm = sqrt(anrm2_glob)
-  if (anrm == 0.d0) anrm = 1.d0
-
   no_conv = .true.
   totit = 0;  
 
@@ -77,20 +66,10 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
     ! --- v_1 = b - A * x (True residual) ---
     call daxpby(n, 1.d0, b(1:n), 1, -1.d0, V(1:n), 1)
 
-    ! --- Denominator for Normwise Backward Error: ||A||_F * ||x||_2 + ||b||_2 ---
-    xnrm = dnrm2(n, x, 1)
-    nbe_denom = anrm * xnrm + bnrm
-
     ! --- rho = ||v_1||_2 ---
     rho = dnrm2(n, V(1:n), 1)
-
-    ! --- Normwise Backward Error: NBE = ||r||_2 / (||A||_F * ||x||_2 + ||b||_2) ---
-    nbe = rho / nbe_denom
-    if (totit .eq. 0) then
-      rho0 = rho
-      scale_norm = max(rho0, bnrm)
-    endif
-    if ((rho/scale_norm < rtol) .or. (nbe < rtol) .or. (rho < atol)) then
+    if (totit .eq. 0) rho0 = rho
+    if ((rho/rho0 < rtol) .or. (rho < atol)) then
       no_conv = .false.
       exit
     endif
@@ -100,7 +79,7 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
     b_(2:restart+1) = 0.d0
     nrit = restart-1
     if (my_id.eq.0) then
-      write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/scale_norm, "nbe =", nbe
+      write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/rho0
       write(*, "(A)") "[GMRES] --- Restart ---"
     endif
 
@@ -163,10 +142,8 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
       b_(it+1) = -givens_s(it)*b_(it)
       b_(it) = givens_c(it)*b_(it)
       rho = abs(b_(it+1))
-      ! --- Normwise Backward Error ---
-      nbe = rho / nbe_denom
-      if (my_id.eq.0) write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/scale_norm, "nbe =", nbe
-      if ((rho < atol).or.(rho/scale_norm < rtol).or.(nbe < rtol).or.(totit >= maxit)) then
+      if (my_id.eq.0) write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/rho0
+      if ((rho < atol).or.(rho/rho0 < rtol).or.(totit >= maxit)) then
         no_conv = .false.
         nrit = it-1
         solver%iter_gmres = totit

--- a/solvers/mod_gmres2.f90
+++ b/solvers/mod_gmres2.f90
@@ -10,7 +10,7 @@ module mod_gmres2
   public :: gmres2_driver
 contains
 
-!> solve a_mat x=b using iterative GMRES method with right preconditioning
+!> solve a_mat x=b using iterative GMRES method with right (or left) preconditioning
 subroutine gmres2_driver(a_mat,b,x,n,solver)
   use mod_sparse_data, only: type_SP_SOLVER
   use data_structure,  only: type_SP_MATRIX
@@ -29,7 +29,6 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
   logical :: GSC=.false., GSM=.false., GSCI=.true., GSMI=.false.
   !> .true.  : right preconditioning, A M^-1 y = b -> minimises the TRUE residual ||b-Ax||
   !> .false. : left  preconditioning, M^-1 A x = M^-1 b -> minimises ||M^-1 (b-Ax)||
-  !>           (this is what the legacy dpackgmres driver does, icntl(4)=1)
   logical :: right_prec=.true.
   !> Relative threshold below which h_{j+1,j} is treated as a (happy) breakdown
   real(kind=8), parameter :: bd_tol = 1.d-14
@@ -64,10 +63,6 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
   ldh = restart+1
 
   ! --- Reference norm for the relative stopping criterion ---
-  !     The caller (mod_sparse) hands us x0 = M^-1 b, i.e. an already good initial guess, so
-  !     ||r0|| is tiny and normalising by it would impose a far stricter test than the legacy
-  !     dpackgmres driver, which measures the backward error against the right hand side.
-  !     Normalise against ||b|| (right prec.) resp. ||M^-1 b|| (left prec.) instead.
   if (right_prec) then
     scale_norm = dnrm2(n, b(1:n), 1)
   else
@@ -162,9 +157,7 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
       endif
       ! --- h_j+1,j = ||v_j+1||_2 ---
       hess(it+(it-1)*ldh+1) = dnrm2(n, V(it*n+1), 1)
-      ! --- Breakdown test: the new direction has been fully cancelled by the orthogonalization,
-      !     i.e. the exact solution already lies in the current Krylov subspace. Normalising here
-      !     would divide by (almost) zero and poison the whole basis with Inf/NaN.
+      ! --- Breakdown test ---
       if (hess(it+(it-1)*ldh+1) .le. bd_tol*max(norm_p, atol)) then
         hess(it+(it-1)*ldh+1) = 0.d0
         V(it*n+1:(it+1)*n) = 0.d0
@@ -216,9 +209,6 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
 
   enddo
 
-  ! --- Report the iteration count on EVERY exit path. The caller derives step_success from
-  !     (iter_gmres < iter_max) and pre-sets iter_gmres = iter_max, so leaving it untouched
-  !     after a successful solve would be reported as a failed step.
   solver%iter_gmres = totit
 
   deallocate(givens_c,givens_s,b_,hess,V,b_prec)

--- a/solvers/mod_gmres2.f90
+++ b/solvers/mod_gmres2.f90
@@ -22,6 +22,7 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
   type(type_SP_SOLVER)  :: solver
   
   real(kind=8) :: atol, rtol, gamma, delta, rho, rho0=0.0, bnrm, scale_norm
+  real(kind=8) :: anrm2_loc, anrm2_glob, anrm, xnrm, nbe, nbe_denom
   real(kind=8) :: norm_p, norm_p_new
   integer :: totit, maxit, restart, nrit, it, ldh, k, j
   integer :: n_ortho 
@@ -56,8 +57,15 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
 
   ldh = restart+1
 
+  ! --- Compute RHS norm ||b||_2 ---
   bnrm = dnrm2(n, b, 1)
   if (bnrm == 0.d0) bnrm = 1.d0
+
+  ! --- Compute global matrix Frobenius norm ||A||_F ---
+  anrm2_loc = dnrm2(int(a_mat%nnz), a_mat%val, 1)**2
+  call MPI_Allreduce(anrm2_loc, anrm2_glob, 1, MPI_DOUBLE_PRECISION, MPI_SUM, MPI_GLOB, ierr)
+  anrm = sqrt(anrm2_glob)
+  if (anrm == 0.d0) anrm = 1.d0
 
   no_conv = .true.
   totit = 0;  
@@ -69,13 +77,20 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
     ! --- v_1 = b - A * x (True residual) ---
     call daxpby(n, 1.d0, b(1:n), 1, -1.d0, V(1:n), 1)
 
+    ! --- Denominator for Normwise Backward Error: ||A||_F * ||x||_2 + ||b||_2 ---
+    xnrm = dnrm2(n, x, 1)
+    nbe_denom = anrm * xnrm + bnrm
+
     ! --- rho = ||v_1||_2 ---
     rho = dnrm2(n, V(1:n), 1)
+
+    ! --- Normwise Backward Error: NBE = ||r||_2 / (||A||_F * ||x||_2 + ||b||_2) ---
+    nbe = rho / nbe_denom
     if (totit .eq. 0) then
       rho0 = rho
       scale_norm = max(rho0, bnrm)
     endif
-    if ((rho/scale_norm < rtol) .or. (rho < atol)) then
+    if ((rho/scale_norm < rtol) .or. (nbe < rtol) .or. (rho < atol)) then
       no_conv = .false.
       exit
     endif
@@ -85,7 +100,7 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
     b_(2:restart+1) = 0.d0
     nrit = restart-1
     if (my_id.eq.0) then
-      write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/scale_norm
+      write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/scale_norm, "nbe =", nbe
       write(*, "(A)") "[GMRES] --- Restart ---"
     endif
 
@@ -148,8 +163,10 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
       b_(it+1) = -givens_s(it)*b_(it)
       b_(it) = givens_c(it)*b_(it)
       rho = abs(b_(it+1))
-      if (my_id.eq.0) write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/scale_norm
-      if ((rho < atol).or.(rho/scale_norm < rtol).or.(totit >= maxit)) then
+      ! --- Normwise Backward Error ---
+      nbe = rho / nbe_denom
+      if (my_id.eq.0) write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/scale_norm, "nbe =", nbe
+      if ((rho < atol).or.(rho/scale_norm < rtol).or.(nbe < rtol).or.(totit >= maxit)) then
         no_conv = .false.
         nrit = it-1
         solver%iter_gmres = totit

--- a/solvers/mod_gmres2.f90
+++ b/solvers/mod_gmres2.f90
@@ -21,7 +21,7 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
   integer :: n
   type(type_SP_SOLVER)  :: solver
   
-  real(kind=8) :: atol, rtol, gamma, delta, rho, rho0=0.0
+  real(kind=8) :: atol, rtol, gamma, delta, rho, rho0=0.0, bnrm, scale_norm
   real(kind=8) :: norm_p, norm_p_new
   integer :: totit, maxit, restart, nrit, it, ldh, k, j
   integer :: n_ortho 
@@ -56,6 +56,9 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
 
   ldh = restart+1
 
+  bnrm = dnrm2(n, b, 1)
+  if (bnrm == 0.d0) bnrm = 1.d0
+
   no_conv = .true.
   totit = 0;  
 
@@ -68,8 +71,11 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
 
     ! --- rho = ||v_1||_2 ---
     rho = dnrm2(n, V(1:n), 1)
-    if (totit .eq. 0) rho0 = rho
-    if ((rho/rho0 < rtol) .or. (rho < atol)) then
+    if (totit .eq. 0) then
+      rho0 = rho
+      scale_norm = max(rho0, bnrm)
+    endif
+    if ((rho/scale_norm < rtol) .or. (rho < atol)) then
       no_conv = .false.
       exit
     endif
@@ -79,7 +85,7 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
     b_(2:restart+1) = 0.d0
     nrit = restart-1
     if (my_id.eq.0) then
-      write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/rho0
+      write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/scale_norm
       write(*, "(A)") "[GMRES] --- Restart ---"
     endif
 
@@ -142,8 +148,8 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
       b_(it+1) = -givens_s(it)*b_(it)
       b_(it) = givens_c(it)*b_(it)
       rho = abs(b_(it+1))
-      if (my_id.eq.0) write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/rho0
-      if ((rho < atol).or.(rho/rho0 < rtol).or.(totit >= maxit)) then
+      if (my_id.eq.0) write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/scale_norm
+      if ((rho < atol).or.(rho/scale_norm < rtol).or.(totit >= maxit)) then
         no_conv = .false.
         nrit = it-1
         solver%iter_gmres = totit

--- a/solvers/mod_gmres2.f90
+++ b/solvers/mod_gmres2.f90
@@ -21,7 +21,7 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
   integer :: n
   type(type_SP_SOLVER)  :: solver
   
-  real(kind=8) :: atol, rtol, gamma, delta, rho, scale_norm
+  real(kind=8) :: atol, rtol, gamma, delta, rho, rho0, scale_norm, res_target
   real(kind=8) :: norm_p, norm_p_new
   integer :: totit, maxit, restart, nrit, it, ldh, k, j
   integer :: n_ortho
@@ -32,6 +32,9 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
   logical :: right_prec=.true.
   !> Relative threshold below which h_{j+1,j} is treated as a (happy) breakdown
   real(kind=8), parameter :: bd_tol = 1.d-14
+  !> Smallest relative residual ||r||/||b|| that is attainable in double precision. The
+  !> convergence target is never set below this, otherwise we chase round-off until iter_max.
+  real(kind=8), parameter :: res_floor = 1.d-14
   real(kind=8), dimension(:), allocatable, target :: givens_c, givens_s, hess, V, b_prec, b_, s_
 
   integer :: my_id, my_id_n, n_cpu, ierr
@@ -75,6 +78,9 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
   breakdown = .false.
   totit = 0
 
+  rho0       = 0.d0
+  res_target = 0.d0
+
   do while (no_conv)
     ! --- v_1 = A * x ---
     call bcsr_matv(a_mat, x, V(1:n))
@@ -90,7 +96,14 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
 
     ! --- rho = ||v_1||_2 ---
     rho = dnrm2(n, V(1:n), 1)
-    if ((rho/scale_norm < rtol) .or. (rho < atol)) then
+
+    ! --- Convergence target ---
+    if (totit .eq. 0) then
+      rho0 = rho
+      res_target = max(rtol*rho0, res_floor*scale_norm)
+    endif
+
+    if ((rho .le. res_target) .or. (rho < atol)) then
       no_conv = .false.
       exit
     endif
@@ -100,7 +113,8 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
     b_(2:restart+1) = 0.d0
     nrit = restart-1
     if (my_id.eq.0) then
-      write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/scale_norm
+      write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6, X, A, X, ES14.6)") &
+        "[GMRES] iteration", totit, "res =", rho, "res/res0 =", rho/rho0, "res/rhs =", rho/scale_norm
       write(*, "(A)") "[GMRES] --- Restart ---"
     endif
 
@@ -186,8 +200,9 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
       b_(it+1) = -givens_s(it)*b_(it)
       b_(it) = givens_c(it)*b_(it)
       rho = abs(b_(it+1))
-      if (my_id.eq.0) write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6)") "[GMRES] iteration", totit, "res =", rho, "rel.res =", rho/scale_norm
-      if ((rho < atol).or.(rho/scale_norm < rtol).or.(totit >= maxit).or.breakdown) then
+      if (my_id.eq.0) write(*, "(A, X, I0, X, A, X, ES14.6, X, A, X, ES14.6, X, A, X, ES14.6)") &
+        "[GMRES] iteration", totit, "res =", rho, "res/res0 =", rho/rho0, "res/rhs =", rho/scale_norm
+      if ((rho .le. res_target).or.(rho < atol).or.(totit >= maxit).or.breakdown) then
         no_conv = .false.
         nrit = it-1
         exit

--- a/solvers/mod_gmres2.f90
+++ b/solvers/mod_gmres2.f90
@@ -10,7 +10,7 @@ module mod_gmres2
   public :: gmres2_driver
 contains
 
-!> solve a_mat x=b using iterative GMRES method with left preconditioning
+!> solve a_mat x=b using iterative GMRES method with right preconditioning
 subroutine gmres2_driver(a_mat,b,x,n,solver)
   use mod_sparse_data, only: type_SP_SOLVER
   use data_structure,  only: type_SP_MATRIX
@@ -55,9 +55,6 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
   givens_s(1:restart) = 0.
 
   ldh = restart+1
-  call dcopy(n, b, 1, b_prec, 1)
-  ! --- b = M^-1 b --- 
-  call prec(solver, b_prec, b_prec, n, MPI_GLOB, MPI_COMM_N)
 
   no_conv = .true.
   totit = 0;  
@@ -65,12 +62,9 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
   do while (no_conv)
     ! --- v_1 = A * x ---
     call bcsr_matv(a_mat, x, V(1:n))
-    
-    ! --- v_1 = M^-1 v_1 ---
-    call prec(solver, V(1:n), V(1:n), n, MPI_GLOB, MPI_COMM_N)
 
-    ! --- v_1 = b - v_1 (Preconditioned residual) ---
-    call daxpby(n, 1.d0, b_prec(1:n), 1, -1.d0, V(1:n), 1)
+    ! --- v_1 = b - A * x (True residual) ---
+    call daxpby(n, 1.d0, b(1:n), 1, -1.d0, V(1:n), 1)
 
     ! --- rho = ||v_1||_2 ---
     rho = dnrm2(n, V(1:n), 1)
@@ -91,11 +85,11 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
 
     do it = 1, restart
       totit = totit +1
-      ! --- v_j+1 = A * v_j --- 
-      call bcsr_matv(a_mat, V((it-1)*n+1:it*n), V(it*n+1: (it+1)*n))
-      
-      ! --- v_j+1 = M^-1 v_j+1 --- 
-      call prec(solver, V(it*n+1:it*n+n), V(it*n+1:it*n+n), n, MPI_GLOB, MPI_COMM_N)
+      ! --- b_prec = M^-1 * v_j --- 
+      call prec(solver, V((it-1)*n+1:it*n), b_prec(1:n), n, MPI_GLOB, MPI_COMM_N)
+
+      ! --- v_j+1 = A * b_prec = A * M^-1 * v_j --- 
+      call bcsr_matv(a_mat, b_prec(1:n), V(it*n+1:(it+1)*n))
 
       ! --- Orthogonalization ---
       if (GSC) then ! Gram-Schmidt Classical
@@ -159,8 +153,11 @@ subroutine gmres2_driver(a_mat,b,x,n,solver)
     enddo
     ! --- Solve upper triangular system b_ = H \ b_ ---
     call dtrsv('U', 'N', 'N', nrit+1, hess, ldh, b_, 1)
-    ! --- Update the solution x = x + V * b_ --- 
-    call dgemv('N', n, nrit+1, 1.d0, V(1), n, b_(1), 1, 1.d0, x, 1)
+    ! --- Form z = V * b_ --- 
+    call dgemv('N', n, nrit+1, 1.d0, V(1), n, b_(1), 1, 0.d0, b_prec(1:n), 1)
+    ! --- Update solution x = x + M^-1 * z ---
+    call prec(solver, b_prec(1:n), V(1:n), n, MPI_GLOB, MPI_COMM_N)
+    call daxpy(n, 1.d0, V(1:n), 1, x(1:n), 1)
 
   enddo
 


### PR DESCRIPTION
# GMRES Driver Improvements 

The current GMRES driver was left-preconditioned only and its stopping criterium was based on the preconditioned relative residual (standard for left preconditioned Krylov methods). 

---

The update delivers following improvements aiming at improving robustness and reducing iteration counts in a variety of simulations:

- Fixed a bug in the Gram-Schmidt orthogonalization loops which could cause unnecessary iterations.
- Added switch for right preconditioning -> Default set to right in since we can capture the true residual.
- Added a breakdown guard that allows for "happy" breakdown of the Krylov subspace and thus early exiting. 
- Added right hand side normalized stopping criterion which better accounts for good initial guesses. 