### PR TITLE
Run github action only in main repository

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event.repository.fork != true
     runs-on: ubuntu-latest
     # The Jekyll site lives in docs/ (source root). Run steps there.
     defaults:
@@ -48,6 +49,7 @@ jobs:
           path: docs/_site
 
   deploy:
+    if: github.event.repository.fork != true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,12 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [develop]
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
   workflow_dispatch:
 
 permissions:
@@ -16,7 +22,6 @@ concurrency:
 
 jobs:
   build:
-    if: github.event.repository.fork != true
     runs-on: ubuntu-latest
     # The Jekyll site lives in docs/ (source root). Run steps there.
     defaults:
@@ -49,7 +54,7 @@ jobs:
           path: docs/_site
 
   deploy:
-    if: github.event.repository.fork != true
+    if: ${{ github.event.repository.fork != true && github.ref == 'refs/heads/develop' }} # Only deploy from the develop branch if not a fork
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Hi Luca and Edoardo,

The actions in forks are disabled by default. However,once they are enabled, this workflow will fail.
This change allows the execution of the pages workflow in the main repository only.


