### PR TITLE
Improve cutoffs to keep_current_source

### DIFF
--- a/communication/broadcast_phys.f90
+++ b/communication/broadcast_phys.f90
@@ -809,6 +809,10 @@ if (my_id .eq. 0) then
   call MPI_PACK(domm,                   1,MPI_LOGICAL,buffer,bufsize,position,MPI_COMM_WORLD,ierr)
   call MPI_PACK(normalized_velocity_profile,1,MPI_LOGICAL,buffer,bufsize,position,MPI_COMM_WORLD,ierr)
   call MPI_PACK(keep_current_prof,      1,MPI_LOGICAL,buffer,bufsize,position,MPI_COMM_WORLD,ierr)
+  call MPI_PACK(keep_current_prof_confined,1,MPI_LOGICAL,buffer,bufsize,position,MPI_COMM_WORLD,ierr)
+  call MPI_PACK(keep_current_psin_cutoff,1,MPI_REAL8  ,buffer,bufsize,position,MPI_COMM_WORLD,ierr)
+  call MPI_PACK(keep_current_psin_sig,  1,MPI_REAL8  ,buffer,bufsize,position,MPI_COMM_WORLD,ierr)
+  call MPI_PACK(keep_current_z_sig,     1,MPI_REAL8  ,buffer,bufsize,position,MPI_COMM_WORLD,ierr)
   call MPI_PACK(init_current_prof,      1,MPI_LOGICAL,buffer,bufsize,position,MPI_COMM_WORLD,ierr)
   call MPI_PACK(current_prof_initialized,1,MPI_LOGICAL,buffer,bufsize,position,MPI_COMM_WORLD,ierr)
 
@@ -1801,6 +1805,10 @@ if (my_id .ne. 0) then
   call MPI_UNPACK(buffer,bufsize,position,domm,                   1,MPI_LOGICAL,MPI_COMM_WORLD,ierr)
   call MPI_UNPACK(buffer,bufsize,position,normalized_velocity_profile,1,MPI_LOGICAL,MPI_COMM_WORLD,ierr)
   call MPI_UNPACK(buffer,bufsize,position,keep_current_prof,      1,MPI_LOGICAL,MPI_COMM_WORLD,ierr)
+  call MPI_UNPACK(buffer,bufsize,position,keep_current_prof_confined,1,MPI_LOGICAL,MPI_COMM_WORLD,ierr)
+  call MPI_UNPACK(buffer,bufsize,position,keep_current_psin_cutoff,1,MPI_REAL8  ,MPI_COMM_WORLD,ierr)
+  call MPI_UNPACK(buffer,bufsize,position,keep_current_psin_sig,  1,MPI_REAL8  ,MPI_COMM_WORLD,ierr)
+  call MPI_UNPACK(buffer,bufsize,position,keep_current_z_sig,     1,MPI_REAL8  ,MPI_COMM_WORLD,ierr)
   call MPI_UNPACK(buffer,bufsize,position,init_current_prof,      1,MPI_LOGICAL,MPI_COMM_WORLD,ierr)
   call MPI_UNPACK(buffer,bufsize,position,current_prof_initialized,1,MPI_LOGICAL,MPI_COMM_WORLD,ierr)
 

--- a/models/current.f90
+++ b/models/current.f90
@@ -20,7 +20,7 @@ real*8,  intent(in)    :: psi_bnd
 real*8,  intent(out)   :: zjz        ! Current at the given position.
 
 ! --- local variables
-real*8  :: psi_n
+real*8  :: psi_n, mask
 real*8  :: zn,dn_dpsi,dn_dz,dn_dpsi2,dn_dz2,dn_dpsi_dz,dn_dpsi3,dn_dpsi_dz2,dn_dpsi2_dz
 real*8  :: zT,dT_dpsi,dT_dz,dT_dpsi2,dT_dz2,dT_dpsi_dz,dT_dpsi3,dT_dpsi_dz2,dT_dpsi2_dz
 real*8  :: zTi,zTe,dTi_dpsi,dTe_dpsi,dTi_dz,dTe_dz,dTi_dpsi2,dTe_dpsi2,dTi_dz2,dTe_dz2
@@ -58,6 +58,23 @@ zjz   = zFFprime - R*R * (zn * dT_dpsi + dn_dpsi * zT)
 !if ((bootstrap) .and. (restart)) then
 !  zjz   = zjz * (0.5d0 - 0.5d0* tanh( (psi_n - (FF_coef(7)-FF_coef(8)))/FF_coef(8) ) )
 !endif
+
+! --- Restrict the current source to the confined region: the input profiles are not exactly
+!     zero on open field lines (tanh tails in the SOL; psi_N < 1 again in the private flux
+!     region, where the profiles evaluate to near-separatrix core values and are only damped
+!     by the wide tanh(Z) cutoffs), and the eta*(j-j0) drive is stiffest where the plasma is
+!     cold. Masks in psi_N towards the SOL and, more sharply than the profile routines, in Z
+!     beyond the X-point(s) towards the private flux region.
+if (keep_current_prof_confined) then
+  mask = 0.5d0 * (1.d0 - tanh((psi_n - keep_current_psin_cutoff)/keep_current_psin_sig))
+  if (xpoint2) then
+    if (xcase2 .ne. UPPER_XPOINT) & ! mask below the lower X-point
+      mask = mask * 0.5d0 * (1.d0 - tanh((Z_xpoint(1) - Z)/keep_current_z_sig))
+    if (xcase2 .ne. LOWER_XPOINT) & ! mask above the upper X-point
+      mask = mask * 0.5d0 * (1.d0 - tanh((Z - Z_xpoint(2))/keep_current_z_sig))
+  endif
+  zjz = zjz * mask
+endif
 
 return
 end subroutine current

--- a/models/mod_log_params.f90
+++ b/models/mod_log_params.f90
@@ -645,6 +645,10 @@ write(*,'(1x,a)',advance='no') ' USE_DOMM            : '
 
 
   write(*,LOGI_FMT) 'keep_current_prof     ', keep_current_prof
+  write(*,LOGI_FMT) 'keep_current_prof_confined', keep_current_prof_confined
+  write(*,REAL_FMT) 'keep_current_psin_cutoff', keep_current_psin_cutoff
+  write(*,REAL_FMT) 'keep_current_psin_sig ', keep_current_psin_sig
+  write(*,REAL_FMT) 'keep_current_z_sig    ', keep_current_z_sig
   write(*,LOGI_FMT) 'init_current_prof     ', init_current_prof
   write(*,LOGI_FMT) 'current_prof_initialized', current_prof_initialized
   write(*,LOGI_FMT) 'linear_run            ', linear_run

--- a/models/model600/initialise_parameters.f90
+++ b/models/model600/initialise_parameters.f90
@@ -21,6 +21,8 @@ integer :: ierr,err,i
 ! --- Namelist with input parameters.
 namelist /in1/  tstep, nstep, tstep_n, nstep_n,                     &
                 rst_hdf5, rst_hdf5_version, keep_current_prof,      &
+                keep_current_prof_confined, keep_current_psin_cutoff, &
+                keep_current_psin_sig, keep_current_z_sig,          &
                 eta, visco, visco_par, visco_par_par,               &
                 restart, rst_format, regrid, bootstrap, write_ps,   &
                 bootstrap_psin_cutoff,                              &

--- a/models/phys_module.f90
+++ b/models/phys_module.f90
@@ -907,6 +907,10 @@ module phys_module
 
   !> @name Flag to determine whether or not we keep current source term  
   logical             :: keep_current_prof !< Artificial current source to approximately keep the initial current profile, i.e., \f$\eta(j-j0)\f$?
+  logical             :: keep_current_prof_confined !< Restrict the keep_current_prof source to the confined region via smooth tanh masks (suppressed in SOL and private flux region)
+  real*8              :: keep_current_psin_cutoff   !< Center of the tanh mask in psi_N for keep_current_prof_confined
+  real*8              :: keep_current_psin_sig      !< Width of the tanh mask in psi_N for keep_current_prof_confined
+  real*8              :: keep_current_z_sig         !< Width of the tanh mask in Z beyond the X-point(s) for keep_current_prof_confined (masks the private flux region where psi_N < 1)
   logical             :: init_current_prof !< Initialize the current source from the current profile present
   logical             :: current_prof_initialized !< Flag that is automatically set to true once the current source has been initialized to prevent accidental reinitialization when restarting
   

--- a/models/preset_parameters.f90
+++ b/models/preset_parameters.f90
@@ -653,6 +653,10 @@ subroutine preset_parameters
   tgnum_A3           = 0.d0
 
   keep_current_prof  = .true.               ! Keep the current_source term
+  keep_current_prof_confined = .false.      ! Apply the current_source term only in the confined region
+  keep_current_psin_cutoff   = 0.98d0
+  keep_current_psin_sig      = 0.01d0
+  keep_current_z_sig         = 0.02d0
   init_current_prof  = .false.
   current_prof_initialized = .false.
   


### PR DESCRIPTION
Running with `keep_current_prof=.true` introduced spurious SOL currents for my case. Namelist input cutoff options have been implemented to mitigate this, and at the same time keep the current profile in the confined region (such as bootstrap current).

New parameters can be used when `keep_current_prof=.true`, for example:
```
keep_current_prof = .true.
keep_current_prof_confined = .true.
keep_current_psin_cutoff = 0.995
keep_current_psin_sig = 0.005
keep_current_z_sig = 0.02
```

(LSN AUG case)