### PR TITLE
Set limits_coll to 1 eV

### DIFF
--- a/docs/code_development/development_workflow.md
+++ b/docs/code_development/development_workflow.md
@@ -173,6 +173,12 @@ During the migration to GitHub, the history of commit hashes will change. Follow
      git push -u origin <branch-name>
 ```
 
+  - You might need to use the following command to make the branch track your fork
+
+```bash             
+     git branch feature/m600refluid  -u origin/feature/m600refluid
+```
+
    The old branch and the public repository share the same history, so the
    commits attach where they always were: nothing is rewritten and there are
    no conflicts to resolve. 

--- a/particles/mod_particle_evolution.f90
+++ b/particles/mod_particle_evolution.f90
@@ -394,11 +394,11 @@ contains
           call sim%fields%calc_NeTeTi(t, particle_tmp%i_elm, particle_tmp%st, particle_tmp%x(3),n_e=n_i, T_e=T_e, T_i=T_i, n_e_raw=n_e_raw, &
                             T_e_raw=T_e_raw, T_i_raw=T_i_raw, grad_T_i=grad_T_i)
           limits = (n_e_raw .le. 1e14) .or. (T_e_raw * K_BOLTZ / EL_CHG .le. 1.d0) .or. (T_i_raw * K_BOLTZ / EL_CHG .le. 1.d0) !ADAS limits
-          limits_coll = T_i_raw * K_BOLTZ / EL_CHG < 0.d0 !< limits for collisions
+          limits_coll = T_i_raw * K_BOLTZ / EL_CHG < 1.d0 !< limits for collisions
 #else
           call sim%fields%calc_NeTeTi(t, particle_tmp%i_elm, particle_tmp%st, particle_tmp%x(3), n_e=n_i, T_e=T_e, n_e_raw=n_e_raw, T_e_raw=T_e_raw, grad_T_e=grad_T_i)
           limits = (n_e_raw .le. 1e14) .or. (T_e_raw * K_BOLTZ / EL_CHG .le. 1.d0)
-          limits_coll = T_e_raw * K_BOLTZ / EL_CHG < 0.d0 !< limits for collisions
+          limits_coll = T_e_raw * K_BOLTZ / EL_CHG < 1.d0 !< limits for collisions
 #endif
 
         !> loop over impurities groups and calculate their contribution to electron density


### PR DESCRIPTION
A temperature limit for the background-impurity collisions is used, previously this was hardcoded to 0 eV, but lead to unstable runs. Better stability is achieved when the limit matches the ADAS limits.

This is a quick fix, in the future more sophisticated limits will be implemented.