### PR TITLE
correct bug in BB2 expression in the uncoupled projection matrix for n=0

### DIFF
--- a/particles/diagnostics/mod_uncoupled_projection.f90
+++ b/particles/diagnostics/mod_uncoupled_projection.f90
@@ -928,7 +928,7 @@ contains
           psi_y = (- x_t(ms,mt) * psi_s(ms,mt) + x_s(ms,mt) * psi_t(ms,mt)) / xjac
 
           BB2 = 1.d0
-          if (filter_parallel_n0 .gt. 0.d0) BB2 = (F0*F0 + psi_x * psi_x + psi_y * psi_y )/x_g(ms,mt)
+          if (filter_parallel_n0 .gt. 0.d0) BB2 = (F0*F0 + psi_x * psi_x + psi_y * psi_y )/x_g(ms,mt)**2
 
           area   = area   + xjac * wst
           volume = volume + TWOPI * x_g(ms,mt) * xjac * wst


### PR DESCRIPTION
corrects a bug in the expression for the total magnetic field (squared) BB2